### PR TITLE
[codex] add neutral MTR interfaces and lifecycle scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 Full ML infrastructure pipeline for ROS2. Includes inference model-agnostic node containers for quick deployment and testing of ML models, as well as sample model farm for building, training, evaluating, and quantizing neural networks.
 
-## Motion Transformer scaffolding
-
-`deep_mtr` provides neutral ROS interfaces and a lifecycle-node integration boundary for future
-Motion Transformer inference. It is intentionally non-inferencing: incoming scenes produce a
-bounded diagnostic and no prediction message until model-specific history, tensor preparation,
-ONNX execution, and output decoding are implemented.
-
 ## Installation
 
 (TODO) Add the base library into the ROS buildfarm

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Full ML infrastructure pipeline for ROS2. Includes inference model-agnostic node containers for quick deployment and testing of ML models, as well as sample model farm for building, training, evaluating, and quantizing neural networks.
 
+## Motion Transformer scaffolding
+
+`deep_mtr` provides neutral ROS interfaces and a lifecycle-node integration boundary for future
+Motion Transformer inference. It is intentionally non-inferencing: incoming scenes produce a
+bounded diagnostic and no prediction message until model-specific history, tensor preparation,
+ONNX execution, and output decoding are implemented.
+
 ## Installation
 
 (TODO) Add the base library into the ROS buildfarm

--- a/deep_msgs/CMakeLists.txt
+++ b/deep_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -31,8 +32,19 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/MultiImageCompressed.msg"
   "msg/MultiCameraInfo.msg"
   "msg/MultiDetection2DArray.msg"
-  DEPENDENCIES std_msgs sensor_msgs vision_msgs
+  "msg/MapPolyline.msg"
+  "msg/MtrScene.msg"
+  "msg/MtrTrajectory.msg"
+  "msg/MtrObjectPrediction.msg"
+  "msg/MtrPredictionArray.msg"
+  DEPENDENCIES geometry_msgs std_msgs sensor_msgs vision_msgs
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_mtr_messages test/test_mtr_messages.cpp)
+  rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  target_link_libraries(test_mtr_messages "${cpp_typesupport_target}")
+endif()
 
 ament_package()

--- a/deep_msgs/msg/MapPolyline.msg
+++ b/deep_msgs/msg/MapPolyline.msg
@@ -1,0 +1,7 @@
+uint8 CENTERLINE=0
+uint8 LEFT_BOUNDARY=1
+uint8 RIGHT_BOUNDARY=2
+
+int64 lanelet_id
+uint8 semantic_type
+geometry_msgs/Point[] points

--- a/deep_msgs/msg/MtrObjectPrediction.msg
+++ b/deep_msgs/msg/MtrObjectPrediction.msg
@@ -1,0 +1,2 @@
+string track_id
+MtrTrajectory[] trajectories

--- a/deep_msgs/msg/MtrPredictionArray.msg
+++ b/deep_msgs/msg/MtrPredictionArray.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+string request_id
+MtrObjectPrediction[] objects

--- a/deep_msgs/msg/MtrScene.msg
+++ b/deep_msgs/msg/MtrScene.msg
@@ -1,0 +1,7 @@
+std_msgs/Header header
+string request_id
+vision_msgs/Detection3DArray detections
+geometry_msgs/PoseStamped ego_pose
+bool has_ego_pose
+MapPolyline[] map_polylines
+bool has_map

--- a/deep_msgs/msg/MtrTrajectory.msg
+++ b/deep_msgs/msg/MtrTrajectory.msg
@@ -1,0 +1,2 @@
+float32 confidence
+geometry_msgs/PoseStamped[] poses

--- a/deep_msgs/package.xml
+++ b/deep_msgs/package.xml
@@ -7,10 +7,13 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>vision_msgs</depend>
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
   <export>
     <build_type>ament_cmake</build_type>

--- a/deep_msgs/test/test_mtr_messages.cpp
+++ b/deep_msgs/test/test_mtr_messages.cpp
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-present WATonomous. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 
 #include <deep_msgs/msg/map_polyline.hpp>

--- a/deep_msgs/test/test_mtr_messages.cpp
+++ b/deep_msgs/test/test_mtr_messages.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include <deep_msgs/msg/map_polyline.hpp>
+#include <deep_msgs/msg/mtr_prediction_array.hpp>
+#include <deep_msgs/msg/mtr_scene.hpp>
+
+TEST(MtrMessages, PreserveCorrelationAndSemanticMapData)
+{
+  deep_msgs::msg::MtrScene scene;
+  scene.request_id = "request-7";
+  scene.has_ego_pose = true;
+  scene.has_map = true;
+
+  deep_msgs::msg::MapPolyline centerline;
+  centerline.lanelet_id = 42;
+  centerline.semantic_type = deep_msgs::msg::MapPolyline::CENTERLINE;
+  centerline.points.resize(2);
+  scene.map_polylines.push_back(centerline);
+
+  EXPECT_EQ(scene.request_id, "request-7");
+  ASSERT_EQ(scene.map_polylines.size(), 1u);
+  EXPECT_EQ(scene.map_polylines.front().lanelet_id, 42);
+  EXPECT_EQ(scene.map_polylines.front().semantic_type, deep_msgs::msg::MapPolyline::CENTERLINE);
+
+  deep_msgs::msg::MtrPredictionArray result;
+  result.request_id = scene.request_id;
+  EXPECT_EQ(result.request_id, scene.request_id);
+}

--- a/deep_mtr/CMakeLists.txt
+++ b/deep_mtr/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.22)
+project(deep_mtr)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ament_cmake REQUIRED)
+find_package(deep_core REQUIRED)
+find_package(deep_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+
+add_library(deep_mtr_component SHARED src/deep_mtr_node.cpp)
+target_include_directories(deep_mtr_component PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_link_libraries(deep_mtr_component PUBLIC
+  pluginlib::pluginlib rclcpp::rclcpp rclcpp_components::component
+  rclcpp_lifecycle::rclcpp_lifecycle ${deep_msgs_TARGETS}
+  PRIVATE deep_core::deep_core_lib)
+rclcpp_components_register_node(deep_mtr_component
+  PLUGIN deep_mtr::DeepMtrNode EXECUTABLE deep_mtr_node)
+
+install(TARGETS deep_mtr_component EXPORT export_deep_mtr
+  ARCHIVE DESTINATION lib LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
+install(DIRECTORY include/ DESTINATION include)
+
+if(BUILD_TESTING)
+  find_package(deep_test REQUIRED)
+  add_deep_test(test_deep_mtr_node test/test_deep_mtr_node.cpp
+    LIBRARIES deep_mtr_component deep_core::deep_core_lib)
+endif()
+
+ament_export_targets(export_deep_mtr HAS_LIBRARY_TARGET)
+ament_package()

--- a/deep_mtr/CMakeLists.txt
+++ b/deep_mtr/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright (c) 2025-present WATonomous. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 cmake_minimum_required(VERSION 3.22)
 project(deep_mtr)
 set(CMAKE_CXX_STANDARD 17)
@@ -25,6 +38,7 @@ rclcpp_components_register_node(deep_mtr_component
 install(TARGETS deep_mtr_component EXPORT export_deep_mtr
   ARCHIVE DESTINATION lib LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
 install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY config launch DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(deep_test REQUIRED)

--- a/deep_mtr/DEVELOPING.md
+++ b/deep_mtr/DEVELOPING.md
@@ -1,0 +1,27 @@
+# Deep MTR Development Boundary
+
+This package owns the future model-specific Motion Transformer implementation. The current node is
+only lifecycle and message-contract scaffolding.
+
+The inference owner must implement these seams in `deep_mtr`:
+
+1. Maintain per-track history from repeated `MtrScene` messages.
+2. Pack the verified MTR ONNX input contract.
+3. Call `DeepNodeBase::run_inference` through `onnxruntime_gpu`.
+4. Decode outputs into `MtrPredictionArray`.
+5. Add real-model contract, correctness, and GPU tests.
+
+The eventual deployment configuration is expected to select:
+
+```yaml
+Backend:
+  plugin: "onnxruntime_gpu"
+  execution_provider: "tensorrt"
+```
+
+The backend must execute an ONNX model through ONNX Runtime's TensorRT execution provider. Do not
+load serialized TensorRT `.engine` files directly: that bypasses the `DeepNodeBase` backend contract
+and introduces hardware- and runtime-specific artifacts into the ROS interface layer.
+
+WATO-specific lanelet adaptation, request correlation, fallback prediction, and world-model output
+remain the responsibility of the consuming bridge, not `deep_mtr` or `deep_msgs`.

--- a/deep_mtr/README.md
+++ b/deep_mtr/README.md
@@ -1,0 +1,23 @@
+# Deep MTR
+
+`deep_mtr` is buildable migration scaffolding for Motion Transformer integration. It defines a
+lifecycle node that accepts semantic `deep_msgs/msg/MtrScene` requests, but it does not run MTR and
+does not publish `deep_msgs/msg/MtrPredictionArray` results.
+
+The node is deliberately safe to launch without a model. While active, it logs a throttled warning
+for incoming scene requests and produces no fabricated predictions.
+
+## Topics
+
+- Input: `/mtr/scenes`
+- Reserved output: `/mtr/predictions`
+
+Both topic names are configurable through `config/deep_mtr.yaml`.
+
+## Lifecycle
+
+The node creates its publisher during configuration and subscribes to scenes only while active.
+Configure and activate it with standard ROS 2 lifecycle commands when testing the scaffold.
+
+Working inference is intentionally excluded. See `DEVELOPING.md` for the implementation ownership
+boundary.

--- a/deep_mtr/config/deep_mtr.yaml
+++ b/deep_mtr/config/deep_mtr.yaml
@@ -1,0 +1,10 @@
+---
+deep_mtr_node:
+  ros__parameters:
+    Backend:
+      plugin: ""
+    model_path: ""
+    Bond:
+      enable: false
+    input_topic: "/mtr/scenes"
+    output_topic: "/mtr/predictions"

--- a/deep_mtr/include/deep_mtr/deep_mtr_node.hpp
+++ b/deep_mtr/include/deep_mtr/deep_mtr_node.hpp
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-present WATonomous. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <memory>

--- a/deep_mtr/include/deep_mtr/deep_mtr_node.hpp
+++ b/deep_mtr/include/deep_mtr/deep_mtr_node.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <deep_core/deep_node_base.hpp>
+#include <deep_msgs/msg/mtr_prediction_array.hpp>
+#include <deep_msgs/msg/mtr_scene.hpp>
+
+namespace deep_mtr
+{
+class DeepMtrNode : public deep_ros::DeepNodeBase
+{
+public:
+  explicit DeepMtrNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+protected:
+  deep_ros::CallbackReturn on_configure_impl(const rclcpp_lifecycle::State &) override;
+  deep_ros::CallbackReturn on_activate_impl(const rclcpp_lifecycle::State &) override;
+  deep_ros::CallbackReturn on_deactivate_impl(const rclcpp_lifecycle::State &) override;
+  deep_ros::CallbackReturn on_cleanup_impl(const rclcpp_lifecycle::State &) override;
+
+private:
+  void scene_callback(deep_msgs::msg::MtrScene::ConstSharedPtr scene);
+
+  std::string input_topic_;
+  std::string output_topic_;
+  rclcpp::Subscription<deep_msgs::msg::MtrScene>::SharedPtr scene_sub_;
+  rclcpp_lifecycle::LifecyclePublisher<deep_msgs::msg::MtrPredictionArray>::SharedPtr result_pub_;
+};
+}  // namespace deep_mtr

--- a/deep_mtr/launch/deep_mtr.launch.yaml
+++ b/deep_mtr/launch/deep_mtr.launch.yaml
@@ -1,0 +1,8 @@
+launch:
+  - node:
+      pkg: "deep_mtr"
+      exec: "deep_mtr_node"
+      name: "deep_mtr_node"
+      output: "screen"
+      param:
+        - from: "$(find-pkg-share deep_mtr)/config/deep_mtr.yaml"

--- a/deep_mtr/package.xml
+++ b/deep_mtr/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>deep_mtr</name>
+  <version>0.1.0</version>
+  <description>Lifecycle-node scaffolding for Motion Transformer inference.</description>
+
+  <maintainer email="watonomous@example.com">WATonomous</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>deep_core</depend>
+  <depend>deep_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <test_depend>deep_test</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/deep_mtr/src/deep_mtr_node.cpp
+++ b/deep_mtr/src/deep_mtr_node.cpp
@@ -1,0 +1,54 @@
+#include "deep_mtr/deep_mtr_node.hpp"
+
+#include <functional>
+#include <utility>
+
+namespace deep_mtr
+{
+DeepMtrNode::DeepMtrNode(const rclcpp::NodeOptions & options)
+: DeepNodeBase("deep_mtr_node", options)
+{
+  declare_parameter("input_topic", "/mtr/scenes");
+  declare_parameter("output_topic", "/mtr/predictions");
+}
+
+deep_ros::CallbackReturn DeepMtrNode::on_configure_impl(const rclcpp_lifecycle::State &)
+{
+  input_topic_ = get_parameter("input_topic").as_string();
+  output_topic_ = get_parameter("output_topic").as_string();
+  result_pub_ = create_publisher<deep_msgs::msg::MtrPredictionArray>(output_topic_, 10);
+  return deep_ros::CallbackReturn::SUCCESS;
+}
+
+deep_ros::CallbackReturn DeepMtrNode::on_activate_impl(const rclcpp_lifecycle::State &)
+{
+  result_pub_->on_activate();
+  scene_sub_ = create_subscription<deep_msgs::msg::MtrScene>(
+    input_topic_, 10, std::bind(&DeepMtrNode::scene_callback, this, std::placeholders::_1));
+  return deep_ros::CallbackReturn::SUCCESS;
+}
+
+deep_ros::CallbackReturn DeepMtrNode::on_deactivate_impl(const rclcpp_lifecycle::State &)
+{
+  scene_sub_.reset();
+  result_pub_->on_deactivate();
+  return deep_ros::CallbackReturn::SUCCESS;
+}
+
+deep_ros::CallbackReturn DeepMtrNode::on_cleanup_impl(const rclcpp_lifecycle::State &)
+{
+  scene_sub_.reset();
+  result_pub_.reset();
+  return deep_ros::CallbackReturn::SUCCESS;
+}
+
+void DeepMtrNode::scene_callback(deep_msgs::msg::MtrScene::ConstSharedPtr scene)
+{
+  RCLCPP_WARN_THROTTLE(
+    get_logger(), *get_clock(), 5000,
+    "MTR inference is not implemented; ignoring scene request '%s'", scene->request_id.c_str());
+}
+}  // namespace deep_mtr
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(deep_mtr::DeepMtrNode)

--- a/deep_mtr/src/deep_mtr_node.cpp
+++ b/deep_mtr/src/deep_mtr_node.cpp
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-present WATonomous. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "deep_mtr/deep_mtr_node.hpp"
 
 #include <functional>
@@ -45,8 +59,11 @@ deep_ros::CallbackReturn DeepMtrNode::on_cleanup_impl(const rclcpp_lifecycle::St
 void DeepMtrNode::scene_callback(deep_msgs::msg::MtrScene::ConstSharedPtr scene)
 {
   RCLCPP_WARN_THROTTLE(
-    get_logger(), *get_clock(), 5000,
-    "MTR inference is not implemented; ignoring scene request '%s'", scene->request_id.c_str());
+    get_logger(),
+    *get_clock(),
+    5000,
+    "MTR inference is not implemented; ignoring scene request '%s'",
+    scene->request_id.c_str());
 }
 }  // namespace deep_mtr
 

--- a/deep_mtr/test/test_deep_mtr_node.cpp
+++ b/deep_mtr/test/test_deep_mtr_node.cpp
@@ -1,0 +1,60 @@
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include <catch2/catch_test_macros.hpp>
+#include <deep_msgs/msg/mtr_prediction_array.hpp>
+#include <deep_msgs/msg/mtr_scene.hpp>
+#include <deep_mtr/deep_mtr_node.hpp>
+#include <deep_test/deep_test.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+using namespace std::chrono_literals;
+
+TEST_CASE("DeepMtrNode runs as an empty lifecycle skeleton", "[deep_mtr][lifecycle]")
+{
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+  auto node = std::make_shared<deep_mtr::DeepMtrNode>();
+
+  REQUIRE(node->configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  REQUIRE(node->activate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  REQUIRE(node->deactivate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  REQUIRE(node->cleanup().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+TEST_CASE("DeepMtrNode never fabricates a prediction", "[deep_mtr][placeholder]")
+{
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+  auto node = std::make_shared<deep_mtr::DeepMtrNode>();
+  auto client = std::make_shared<rclcpp::Node>("deep_mtr_test_client");
+  std::atomic<int> result_count{0};
+  auto result_sub = client->create_subscription<deep_msgs::msg::MtrPredictionArray>(
+    "/mtr/predictions", 10,
+    [&result_count](deep_msgs::msg::MtrPredictionArray::ConstSharedPtr) {++result_count;});
+  auto scene_pub = client->create_publisher<deep_msgs::msg::MtrScene>("/mtr/scenes", 10);
+
+  REQUIRE(node->configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  REQUIRE(node->activate().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.add_node(client);
+  deep_msgs::msg::MtrScene scene;
+  scene.request_id = "must-not-produce-output";
+  scene_pub->publish(scene);
+  const auto deadline = std::chrono::steady_clock::now() + 300ms;
+  while (std::chrono::steady_clock::now() < deadline) {
+    executor.spin_some();
+    std::this_thread::sleep_for(10ms);
+  }
+
+  REQUIRE(result_count.load() == 0);
+  node->deactivate();
+  node->cleanup();
+}

--- a/deep_mtr/test/test_deep_mtr_node.cpp
+++ b/deep_mtr/test/test_deep_mtr_node.cpp
@@ -1,3 +1,17 @@
+// Copyright (c) 2025-present WATonomous. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -10,8 +24,6 @@
 #include <deep_test/deep_test.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <rclcpp/rclcpp.hpp>
-
-using namespace std::chrono_literals;
 
 TEST_CASE("DeepMtrNode runs as an empty lifecycle skeleton", "[deep_mtr][lifecycle]")
 {
@@ -35,8 +47,7 @@ TEST_CASE("DeepMtrNode never fabricates a prediction", "[deep_mtr][placeholder]"
   auto client = std::make_shared<rclcpp::Node>("deep_mtr_test_client");
   std::atomic<int> result_count{0};
   auto result_sub = client->create_subscription<deep_msgs::msg::MtrPredictionArray>(
-    "/mtr/predictions", 10,
-    [&result_count](deep_msgs::msg::MtrPredictionArray::ConstSharedPtr) {++result_count;});
+    "/mtr/predictions", 10, [&result_count](deep_msgs::msg::MtrPredictionArray::ConstSharedPtr) { ++result_count; });
   auto scene_pub = client->create_publisher<deep_msgs::msg::MtrScene>("/mtr/scenes", 10);
 
   REQUIRE(node->configure().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
@@ -48,10 +59,10 @@ TEST_CASE("DeepMtrNode never fabricates a prediction", "[deep_mtr][placeholder]"
   deep_msgs::msg::MtrScene scene;
   scene.request_id = "must-not-produce-output";
   scene_pub->publish(scene);
-  const auto deadline = std::chrono::steady_clock::now() + 300ms;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
   while (std::chrono::steady_clock::now() < deadline) {
     executor.spin_some();
-    std::this_thread::sleep_for(10ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
   REQUIRE(result_count.load() == 0);

--- a/deep_mtr/test/test_deep_mtr_node.cpp
+++ b/deep_mtr/test/test_deep_mtr_node.cpp
@@ -17,10 +17,10 @@
 #include <memory>
 #include <thread>
 
-#include <catch2/catch_test_macros.hpp>
 #include <deep_msgs/msg/mtr_prediction_array.hpp>
 #include <deep_msgs/msg/mtr_scene.hpp>
 #include <deep_mtr/deep_mtr_node.hpp>
+#include <deep_test/compat.hpp>
 #include <deep_test/deep_test.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <rclcpp/rclcpp.hpp>


### PR DESCRIPTION
## Summary

- add neutral semantic scene and multimodal trajectory messages to `deep_msgs`
- add a lifecycle-managed `deep_mtr` component that accepts scenes but intentionally publishes no predictions
- document the inference-owner boundary and provide backend-neutral configuration and launch assets

## Intentional limitation

Working MTR inference is excluded from this change. The node logs a throttled diagnostic for incoming scene requests and deliberately emits no result until per-track history, tensor packing, ONNX Runtime execution, and output decoding are implemented by the inference owner.

## Validation

- `pre-commit run --all-files`
- ROS 2 Jazzy full repository build with `IS_CI=1` on `linux/amd64`
- full CPU test suite: 719 tests, 0 failures
